### PR TITLE
Moving GA from <head> to Tag Manager at beginning of <body>

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,14 +9,4 @@
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <script>
-     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-     ga('create', 'UA-860026-4', 'auto');
-     ga('send', 'pageview');
-  </script>
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,4 +9,5 @@
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,15 +4,17 @@
   {% include head.html %}
 
   <body>
+
     <!-- Google Tag Manager [phila.gov] -->
-    <noscript>&lt;iframe src="//www.googletagmanager.com/ns.html?id=GTM-MC6CR2"
-    height="0" width="0" style="display:none;visibility:hidden"&gt;&lt;/iframe&gt;</noscript>
-    <script type="text/javascript">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KDM9KV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-MC6CR2');</script>
+    })(window,document,'script','dataLayer','GTM-KDM9KV');</script>
     <!-- End Google Tag Manager -->
+
     {% include header.html %}
 
     <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,15 @@
   {% include head.html %}
 
   <body>
-
+    <!-- Google Tag Manager [phila.gov] -->
+    <noscript>&lt;iframe src="//www.googletagmanager.com/ns.html?id=GTM-MC6CR2"
+    height="0" width="0" style="display:none;visibility:hidden"&gt;&lt;/iframe&gt;</noscript>
+    <script type="text/javascript">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-MC6CR2');</script>
+    <!-- End Google Tag Manager -->
     {% include header.html %}
 
     <div class="container">


### PR DESCRIPTION
slash-data wasn't being tracked as part of primary phila.gov site; moving to Tag manager per rest of site and will fire both current Github -4 GA property, as well as -1 phila.gov tracking from within Tag Manager.
